### PR TITLE
Fix /api/parse to route PDF uploads to pdf_parser.py reliably

### DIFF
--- a/app/routes/parse.py
+++ b/app/routes/parse.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, request, jsonify
 from app.utils.chat_data import supabase
 from app.utils.json_parser import run_from_excel
+from app.utils.pdf_parser import parse_pdf
 from app.utils.advanced_team_stats import compute_team_advanced, fetch_team_stats_for_league
 import traceback
 import logging
@@ -84,13 +85,13 @@ def handle_parse():
         try:
             bucket, filename = file_path.split("/", 1)
             file_bytes = supabase.storage.from_(bucket).download(filename)
-        except Exception:
-            pass  # fall through to run_from_excel which handles local paths too
+        except Exception as download_err:
+            log.warning("Supabase storage download failed for %s: %s", file_path, download_err)
+            return jsonify({"error": f"Storage download failed: {str(download_err)}"}), 500
 
         if file_bytes and file_bytes[:4] == b"%PDF":
             log.info("PDF detected in /api/parse — routing to PDF parser: %s", file_path)
-            from app.utils.pdf_parser import parse_pdf
-            import io
+            log.info("Using pdf_parser.py for /api/parse")
             result = parse_pdf(
                 pdf_file=io.BytesIO(file_bytes),
                 league_name=league_name or "Unknown",


### PR DESCRIPTION
## Task
Fix the /api/parse route so PDF uploads always invoke pdf_parser.parse_pdf instead of silently falling through to json_parser.run_from_excel when the Supabase storage download fails.

## Changes to app/routes/parse.py

1. Added top-level import: `from app.utils.pdf_parser import parse_pdf` alongside the existing json_parser import (line 4). parse_pdf is no longer imported inline inside the if-block.

2. Removed `import io` duplication — io was already imported at the top of the file, so the inline `import io` inside the PDF branch was redundant and is now gone.

3. Fixed the silent exception swallow: replaced `except Exception: pass` with `except Exception as download_err:` that logs a warning and returns a clear JSON 500 error (`{"error": "Storage download failed: ..."}`). PDF uploads that fail to download from Supabase now get an explicit error instead of silently routing to the Excel parser.

4. Added the required log line `log.info("Using pdf_parser.py for /api/parse")` immediately before calling parse_pdf() in the PDF branch.

## No deviations from task spec
All four steps in the task were implemented exactly as described. The Excel branch, /api/parse-pdf endpoint, pdf_parser.py, and the frontend are unchanged.

Replit-Task-Id: 8a5e19b7-130d-478c-baeb-a129841a2ff4